### PR TITLE
Remove exception control in Rack::Logger

### DIFF
--- a/lib/loga/rack/logger.rb
+++ b/lib/loga/rack/logger.rb
@@ -22,18 +22,12 @@ module Loga
 
         smsg = { 'fullpath' => request.fullpath }
 
-        begin
-          @app.call(env).tap do |status, headers, _body|
-            data['status']     = status
-            data['request_id'] = headers['X-Request-Id']
-          end
-        rescue Exception => exception
-          raise exception
-        ensure
-          exception ||= env['action_dispatch.exception'] || env['sinatra.error']
-
-          data['request_id'] ||= env['action_dispatch.request_id']
+        @app.call(env).tap do |status, headers, _body|
+          data['status']     = status
+          data['request_id'] = headers['X-Request-Id'] || env['action_dispatch.request_id']
           data['duration']   = duration_in_ms(started_at, Time.now)
+
+          exception = env['action_dispatch.exception'] || env['sinatra.error']
 
           logger.public_send(exception ? :error : :info,
                              type:          'http_request',


### PR DESCRIPTION
Exceptions must be handled in middleware higher than the logger.
