### PR TITLE
Add configuration to filter sensitive parameters

### DIFF
--- a/lib/loga.rb
+++ b/lib/loga.rb
@@ -12,13 +12,15 @@ module Loga
     :service_name,
     :service_version,
     :device,
+    :filter_parameters,
   )
 
   def self.configuration
     @configuration ||= Configuration.new(
-      service_name: '',
-      service_version: '',
-      device: STDOUT,
+      '',
+      '',
+      STDOUT,
+      [],
     )
   end
 

--- a/lib/loga/rack/logger.rb
+++ b/lib/loga/rack/logger.rb
@@ -16,7 +16,7 @@ module Loga
         data               = {}
         data['method']     = request.request_method
         data['path']       = request.path
-        data['params']     = request.params
+        data['params']     = sanitize_params(request.params)
         data['request_ip'] = request.ip
         data['user_agent'] = request.user_agent
 
@@ -50,6 +50,17 @@ module Loga
 
       def logger
         Loga.logger
+      end
+
+      def filter_parameters
+        Loga.configuration.filter_parameters
+      end
+
+      def sanitize_params(params)
+        (params || {}).each_key do |k|
+          params[k] = '[FILTERED]' if filter_parameters.include? k
+        end
+        params
       end
     end
   end

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -41,7 +41,7 @@ describe 'Rack request logger with Rails' do
     Loga.configure do |config|
       config.service_name    = 'hello_world_app'
       config.service_version = '1.0'
-      config.device      = target
+      config.device          = target
     end
 
     Loga::Logging.reset

--- a/spec/loga/rack/logger_spec.rb
+++ b/spec/loga/rack/logger_spec.rb
@@ -79,5 +79,28 @@ describe Loga::Rack::Logger do
         subject.call(env)
       end
     end
+
+    context 'when filter parameter are present' do
+      let(:env)    { Rack::MockRequest.env_for('/about_us?limit=1&password=hello') }
+
+      before do
+        allow(app).to receive(:call).with(env).and_return([200, {}, ''])
+        allow(subject).to receive(:filter_parameters).and_return(%w(password username))
+      end
+
+      it 'filters the parameters' do
+        expect(logger).to receive(:info)
+          .with(
+            hash_including(
+              data: hash_including(
+                request: hash_including('params' => { 'limit' => '1',
+                                                      'password' => '[FILTERED]' },
+                                       ),
+              ),
+            ),
+          )
+        subject.call(env)
+      end
+    end
   end
 end


### PR DESCRIPTION
Sensitive HTTP request parameters can be filtered out via configuration

``` ruby
Loga.configure do |config|
  config.filter_parameters = ['password']
end
```
