### PR TITLE
Mutliple Rubies on Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,8 @@
+dependencies:
+  override:
+    - rvm-exec 1.9.3-p392 bundle install -j 4
+    - rvm-exec 2.0.0-p353 bundle install -j 4
+test:
+  override:
+    - rvm-exec 1.9.3-p392 bundle exec rake
+    - rvm-exec 2.0.0-p353 bundle exec rake

--- a/loga.gemspec
+++ b/loga.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop',  '~> 0.30.0'
   spec.add_development_dependency 'sinatra',  '~> 1.4.0'
   spec.add_development_dependency 'rails',    '~> 4.1.0'
-  spec.add_development_dependency 'sidekiq',  '~> 3.3.4'
+  spec.add_development_dependency 'sidekiq',  '~> 3.0.1'
 end


### PR DESCRIPTION
- Multi Ruby Circle CI setup
- Decreased sidekiq development dependency because higher versions of sidekiq no longer support ruby 1.9.x
