### PR TITLE
Copy ActiveSupport::TaggedLogging

### DIFF
--- a/lib/loga.rb
+++ b/lib/loga.rb
@@ -1,4 +1,5 @@
 require 'loga/version'
+require 'loga/tagged_logging'
 require 'loga/configuration'
 require 'loga/utilities'
 require 'loga/formatter'

--- a/lib/loga/configuration.rb
+++ b/lib/loga/configuration.rb
@@ -29,7 +29,7 @@ module Loga
       @service_name.to_s.strip!
       @service_version.to_s.strip!
 
-      @logger           = ActiveSupport::TaggedLogging.new(Logger.new(@device))
+      @logger           = TaggedLogging.new(Logger.new(@device))
       @logger.level     = @level
       @logger.formatter = Formatter.new(
         service_name:    @service_name,

--- a/lib/loga/formatter.rb
+++ b/lib/loga/formatter.rb
@@ -4,7 +4,7 @@ require 'active_support/tagged_logging'
 
 module Loga
   class Formatter < Logger::Formatter
-    include ActiveSupport::TaggedLogging::Formatter
+    include TaggedLogging::Formatter
     GELF_VERSION = '1.1'.freeze
     SYSLOG_LEVEL_MAPPING = {
       'DEBUG'   => 7,

--- a/lib/loga/tagged_logging.rb
+++ b/lib/loga/tagged_logging.rb
@@ -1,0 +1,72 @@
+# Shamelessly copied from ActiveSupport::TaggedLogging
+require 'active_support/core_ext/module/delegation'
+require 'active_support/core_ext/object/blank'
+require 'logger'
+
+module Loga
+  # rubocop:disable Metrics/LineLength
+  # Wraps any standard Logger object to provide tagging capabilities.
+  #
+  #   logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  #   logger.tagged('BCX') { logger.info 'Stuff' }                            # Logs "[BCX] Stuff"
+  #   logger.tagged('BCX', "Jason") { logger.info 'Stuff' }                   # Logs "[BCX] [Jason] Stuff"
+  #   logger.tagged('BCX') { logger.tagged('Jason') { logger.info 'Stuff' } } # Logs "[BCX] [Jason] Stuff"
+  #
+  # This is used by the default Rails.logger as configured by Railties to make
+  # it easy to stamp log lines with subdomains, request ids, and anything else
+  # to aid debugging of multi-user production applications.
+  # rubocop:enable Metrics/LineLength
+  module TaggedLogging
+    module Formatter # :nodoc:
+      def tagged(*tags)
+        new_tags = push_tags(*tags)
+        yield self
+      ensure
+        pop_tags(new_tags.size)
+      end
+
+      def push_tags(*tags)
+        tags.flatten.reject(&:blank?).tap do |new_tags|
+          current_tags.concat new_tags
+        end
+      end
+
+      def pop_tags(size = 1)
+        current_tags.pop size
+      end
+
+      def clear_tags!
+        current_tags.clear
+      end
+
+      def current_tags
+        Thread.current[:loga_tagged_logging_tags] ||= []
+      end
+
+      private
+
+      def tags_text
+        tags = current_tags
+        tags.collect { |tag| "[#{tag}] " }.join if tags.any?
+      end
+    end
+
+    def self.new(logger)
+      # Ensure we set a default formatter so we aren't extending nil!
+      # logger.formatter ||= ::Logger::SimpleFormatter.new
+      logger.formatter.extend Formatter
+      logger.extend(self)
+    end
+
+    delegate :push_tags, :pop_tags, :clear_tags!, to: :formatter
+
+    def tagged(*tags)
+      formatter.tagged(*tags) { yield self }
+    end
+
+    def flush
+      clear_tags!
+      super if defined?(super)
+    end
+  end
+end


### PR DESCRIPTION
The TaggedLogging API changed between ActiveSupport 3 and 4. To avoid locking ActiveSupport to a specific version, the necessary TaggedLogging code was imported.
