### PR TITLE
Re-order middleware in Rails to avoid flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ NOTE: must have exception handler (e.g. action_dispatch.exception)
 Rails applications
 ```ruby
 # config/application.rb
-config.middleware.insert_before Rails::Rack::Logger,
-                                Loga::Rack::Logger
+config.middleware.insert_after Rails::Rack::Logger,
+                               Loga::Rack::Logger
 ```
 
 Custom events

--- a/spec/fixtures/rails32/config/application.rb
+++ b/spec/fixtures/rails32/config/application.rb
@@ -59,6 +59,6 @@ module Rails32
     # parameters by using an attr_accessible or attr_protected declaration.
     # config.active_record.whitelist_attributes = true
 
-    config.middleware.insert_before Rails::Rack::Logger, Loga::Rack::Logger
+    config.middleware.insert_after Rails::Rack::Logger, Loga::Rack::Logger, [:uuid]
   end
 end

--- a/spec/fixtures/rails40/config/application.rb
+++ b/spec/fixtures/rails40/config/application.rb
@@ -25,6 +25,6 @@ module Rails40
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
-    config.middleware.insert_before Rails::Rack::Logger, Loga::Rack::Logger
+    config.middleware.insert_after Rails::Rack::Logger, Loga::Rack::Logger, [:uuid]
   end
 end

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -34,7 +34,7 @@ describe 'Rack request logger with Rails', timecop: true do
         '_request.status'     => 200,
         '_request.request_id' => '471a34dc',
         '_request.duration'   => 0,
-        '_tags'               => [],
+        '_tags'               => ['471a34dc'],
       )
     end
   end
@@ -65,7 +65,7 @@ describe 'Rack request logger with Rails', timecop: true do
         '_exception.klass'     => 'StandardError',
         '_exception.message'   => 'Hello Rails Error',
         '_exception.backtrace' => be_a(String),
-        '_tags'               => [],
+        '_tags'               => ['471a34dc'],
       )
     end
   end


### PR DESCRIPTION
Rails::Rack::Logger flushes LogSubscribers when the request finishes. This causes the tags to be flushed. As a result Loga::Rack::Middleware must be inserted before the flush event occurs.
