### PR TITLE
Fulfil license requirements for reusing ActiveSupport code

### DIFF
--- a/lib/loga/tagged_logging.rb
+++ b/lib/loga/tagged_logging.rb
@@ -1,4 +1,8 @@
-# Shamelessly copied from ActiveSupport::TaggedLogging
+# Copy of ActiveSupport::TaggedLogging
+#
+# Copyright and license information: https://github.com/rails/rails/blob/master/activesupport/MIT-LICENSE
+# Original contributors: https://github.com/rails/rails/commits/master/activesupport/lib/active_support/tagged_logging.rb
+
 require 'active_support/core_ext/module/delegation'
 require 'active_support/core_ext/object/blank'
 require 'logger'


### PR DESCRIPTION
...just to comply to MIT license requirements. Please add similar info to any other chunk of code  shamelessly copied from open source projects. 
