### PR TITLE
Use Loga::Configuration in Rails

### DIFF
--- a/lib/loga/configuration.rb
+++ b/lib/loga/configuration.rb
@@ -1,3 +1,6 @@
+require 'logger'
+require 'socket'
+
 module Loga
   class Configuration
     attr_accessor :service_name,
@@ -5,24 +8,21 @@ module Loga
                   :device,
                   :filter_parameters,
                   :level,
-                  :host
+                  :host,
+                  :enable,
+                  :silence_rails_rack_logger
 
     attr_reader :logger
 
-    def initialize(opts = {})
-      defaults = {
-        host:  Socket.gethostname,
-        level: Logger::INFO,
-        device: STDOUT,
-        filter_parameters: [],
-      }
+    def initialize
+      @host              = gethostname
+      @device            = STDOUT
+      @level             = Logger::INFO
+      @filter_parameters = []
 
-      options = defaults.merge(opts)
-
-      @host              = options[:host]
-      @device            = options[:device]
-      @level             = options[:level]
-      @filter_parameters = options[:filter_parameters]
+      # Rails specific configuration
+      @enable            = true
+      @silence_rails_rack_logger = true
     end
 
     def initialize!
@@ -37,6 +37,18 @@ module Loga
         host:            @host,
       )
       @logger
+    end
+
+    def configure
+      yield self
+    end
+
+    private
+
+    def gethostname
+      Socket.gethostname
+    rescue Exception
+      'unknown.host'
     end
   end
 end

--- a/lib/loga/railtie.rb
+++ b/lib/loga/railtie.rb
@@ -1,24 +1,20 @@
+require 'loga'
+
 module Loga
   class Railtie < Rails::Railtie
-    config.loga = ActiveSupport::OrderedOptions.new
-
-    # Consider using Loga::Configuration object instead
-    config.loga.device = STDOUT
-    config.loga.silence_rails_rack_logger = true
+    config.loga = Loga::Configuration.new
 
     initializer :loga_initialize_logger, before: :initialize_logger do |app|
-      io = config.loga.device
+      if Rails::VERSION::MAJOR > 3
+        config.loga.device.sync = app.config.autoflush_log
+      else
+        config.loga.device.sync = true
+      end
 
-      io.sync = app.config.autoflush_log if Rails::VERSION::MAJOR > 3
+      config.loga.level = Logger.const_get(app.config.log_level.to_s.upcase)
+      config.loga.initialize!
 
-      logger = Loga::TaggedLogging.new(Logger.new(io))
-      logger.formatter = Loga::Formatter.new(host:            config.loga.host,
-                                             service_name:    config.loga.service_name,
-                                             service_version: config.loga.service_version)
-
-      logger.level = Logger.const_get(app.config.log_level.to_s.upcase)
-
-      app.config.logger = logger
+      app.config.logger = config.loga.logger
     end
 
     config.after_initialize do |app|

--- a/spec/fixtures/rails32/config/application.rb
+++ b/spec/fixtures/rails32/config/application.rb
@@ -61,9 +61,11 @@ module Rails32
     # parameters by using an attr_accessible or attr_protected declaration.
     # config.active_record.whitelist_attributes = true
     config.log_tags = [:uuid]
-    config.loga.service_name = 'hello_world_app'
-    config.loga.service_version = '1.0'
-    config.loga.host = 'bird.example.com'
-    config.loga.device = STREAM
+    config.loga.configure do |loga|
+      loga.service_name = 'hello_world_app'
+      loga.service_version = '1.0'
+      loga.host = 'bird.example.com'
+      loga.device = STREAM
+    end
   end
 end

--- a/spec/fixtures/rails40/config/application.rb
+++ b/spec/fixtures/rails40/config/application.rb
@@ -27,9 +27,11 @@ module Rails40
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
     config.log_tags = [:uuid]
-    config.loga.service_name = 'hello_world_app'
-    config.loga.service_version = '1.0'
-    config.loga.host = 'bird.example.com'
-    config.loga.device = STREAM
+    config.loga.configure do |loga|
+      loga.service_name = 'hello_world_app'
+      loga.service_version = '1.0'
+      loga.host = 'bird.example.com'
+      loga.device = STREAM
+    end
   end
 end

--- a/spec/unit/loga/configuration_spec.rb
+++ b/spec/unit/loga/configuration_spec.rb
@@ -10,24 +10,55 @@ describe Loga::Configuration do
       specify { expect(subject.service_name).to eq(nil) }
       specify { expect(subject.service_version).to eq(nil) }
     end
+
+    context 'when hostname cannot be resolved' do
+      before do
+        allow(Socket).to receive(:gethostname).and_raise(Exception)
+      end
+
+      it 'uses a default hostname' do
+        expect(subject.host).to eq('unknown.host')
+      end
+    end
   end
 
   describe '#initialize!' do
     subject do
       described_class.new.tap do |config|
-        config.service_name = ' hello_world_app '
+        config.service_name    = ' hello_world_app '
         config.service_version =  " 1.0\n"
       end
     end
 
-    it 'returns a logger' do
-      expect(subject.initialize!).to be_a(Logger)
-    end
-
     it 'initializes the formatter with stiped service name and version' do
       expect(Loga::Formatter).to receive(:new)
-        .with(service_name: 'hello_world_app', service_version: '1.0', host: hostname_anchor)
+        .with(service_name: 'hello_world_app',
+              service_version: '1.0',
+              host: hostname_anchor)
       subject.initialize!
+    end
+  end
+
+  describe '#logger' do
+    context 'when initialized' do
+      before { subject.initialize! }
+      it 'returns a logger' do
+        expect(subject.logger).to be_a(Logger)
+      end
+
+      it 'returns a tagged logger' do
+        expect(subject.logger).to respond_to(:tagged)
+      end
+    end
+
+    context 'when not initialized' do
+      specify { expect(subject.logger).to be_nil }
+    end
+  end
+
+  describe '#configure' do
+    it 'yields self' do
+      expect { |b| subject.configure(&b) }.to yield_with_args(subject)
     end
   end
 end

--- a/spec/unit/loga_spec.rb
+++ b/spec/unit/loga_spec.rb
@@ -13,9 +13,7 @@ describe Loga do
 
   describe '.configure' do
     it 'configures Loga' do
-      expect do
-        subject.configure { |c| c.service_name = 'loga' }
-      end.to change { subject.configuration.service_name }
+      expect { |b| subject.configure(&b) }.to yield_with_args(subject.configuration)
     end
   end
 


### PR DESCRIPTION
- Use Loga::Configuration instead of ActiveSupport::OrderedOptions.
- Sync IO with Rails versions prior to 4.
