### PR TITLE
Disable colorized logging in Rails

### DIFF
--- a/lib/loga/railtie.rb
+++ b/lib/loga/railtie.rb
@@ -61,6 +61,8 @@ module Loga
           when 4 then require 'loga/ext/rails/rack/logger4.rb'
           end
         end
+
+        app.config.colorize_logging = false
       end
     end
   end

--- a/spec/integration/rails/railtie_spec.rb
+++ b/spec/integration/rails/railtie_spec.rb
@@ -42,4 +42,8 @@ RSpec.describe Loga::Railtie do
     expect(middlewares.index(Loga::Rack::Logger))
       .to eq(middlewares.index(Rails::Rack::Logger) + 1)
   end
+
+  it 'disables colorized logging' do
+    expect(app.config.colorize_logging).to eq(false)
+  end
 end


### PR DESCRIPTION
> The art of logging is colorless :art:
> @timstott - 2015-07

**Edit:**
We're disabling colorized logging because Graylog ignores it.
Before:

```
[1m[35mPonies Load (0.3ms)[0m SELECT "ponies".* FROM "ponies" WHERE "ponies"."id" = 6 LIMIT 1]]]
```

After:

```
  Ponies Load (0.3ms) SELECT "ponies".* FROM "ponies" WHERE "ponies"."id" = 6 LIMIT 1
```
