### PR TITLE
Provide strategy to fetch git revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,7 @@ the Railtie.
 # config/environments/production.rb
 ...
 config.loga.configure do |loga|
-  loga.service_name    = 'marketplace'
-  loga.service_version = 'v1.0.0' or SHA
-  config.device        = STDOUT or any instance of IO
+  # See configuration section
 end
 ...
 ```
@@ -52,13 +50,10 @@ In Ruby applications Loga must be required and configured.
 # .../initializers/loga.rb
 require 'loga'
 
-Loga.configure do |config|
-  config.service_name      = 'marketplace'
-  config.service_version   = 'v1.0.0' or SHA
-  config.device            = STDOUT or any instance of IO
+Loga.configure do |loga|
+  # See configuration section
 end
 Loga.initialize!
-
 ```
 Log requests in Rack applications with Loga middleware.
 
@@ -73,6 +68,17 @@ user Marketplace
 run Sinatra::Application
 ```
 
+### Configuration
+
+```ruby
+<loga configuration object>.configure do |loga|
+  loga.service_name    = 'marketplace'
+  loga.service_version = 'v1.0.0' or strategy # default :git
+  loga.device           = STDOUT or any instance of IO
+end
+```
+
+The service_version :git strategy fetches the git revision of the application.
 
 ## Sample output
 

--- a/spec/unit/loga/configuration_spec.rb
+++ b/spec/unit/loga/configuration_spec.rb
@@ -8,7 +8,7 @@ describe Loga::Configuration do
       specify { expect(subject.device).to eq(STDOUT) }
       specify { expect(subject.filter_parameters).to eq([]) }
       specify { expect(subject.service_name).to eq(nil) }
-      specify { expect(subject.service_version).to eq(nil) }
+      specify { expect(subject.service_version).to eq(:git) }
     end
 
     context 'when hostname cannot be resolved' do
@@ -36,6 +36,14 @@ describe Loga::Configuration do
               service_version: '1.0',
               host: hostname_anchor)
       subject.initialize!
+    end
+
+    context 'when service_version is :git' do
+      before { subject.service_version = :git }
+      it 'computes the service_version with git' do
+        subject.initialize!
+        expect(subject.service_version).to match(/\h+/)
+      end
     end
   end
 


### PR DESCRIPTION
Configure with sensible default `:git`.
Intent is to dry configuration in applications.
