### PR TITLE
Improve Rack request message

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,6 @@ Style/TrailingComma:
 
 Style/BlockDelimiters:
   Enabled: false
+
+Style/FormatString:
+  Enabled: false

--- a/lib/loga/rack/logger.rb
+++ b/lib/loga/rack/logger.rb
@@ -59,7 +59,12 @@ module Loga
       end
 
       def compute_message
-        "#{request.request_method} #{request.filtered_full_path}"
+        '%{method} %{filtered_full_path} %{status} in %{duration}ms' % {
+          method:             request.request_method,
+          filtered_full_path: request.filtered_full_path,
+          status:             data['status'],
+          duration:           data['duration'],
+        }
       end
 
       def compute_level

--- a/spec/support/request_spec.rb
+++ b/spec/support/request_spec.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples 'request logger' do
       expect(json).to match(
         'version'             => '1.1',
         'host'                => 'bird.example.com',
-        'short_message'       => 'GET /ok?username=yoshi',
+        'short_message'       => 'GET /ok?username=yoshi 200 in 0ms',
         'timestamp'           => 1_450_150_205.123,
         'level'               => 6,
         '_type'               => 'request',
@@ -38,7 +38,7 @@ RSpec.shared_examples 'request logger' do
       expect(json).to match(
         'version'             => '1.1',
         'host'                => 'bird.example.com',
-        'short_message'       => 'POST /users?username=yoshi',
+        'short_message'       => 'POST /users?username=yoshi 200 in 0ms',
         'timestamp'           => 1_450_150_205.123,
         'level'               => 6,
         '_type'               => 'request',
@@ -69,7 +69,7 @@ RSpec.shared_examples 'request logger' do
       expect(json).to match(
         'version'             => '1.1',
         'host'                => 'bird.example.com',
-        'short_message'       => 'GET /new',
+        'short_message'       => 'GET /new 302 in 0ms',
         'timestamp'           => 1_450_150_205.123,
         'level'               => 6,
         '_type'               => 'request',
@@ -97,7 +97,7 @@ RSpec.shared_examples 'request logger' do
       expect(json).to match(
         'version'              => '1.1',
         'host'                 => 'bird.example.com',
-        'short_message'        => 'GET /error?username=yoshi',
+        'short_message'        => 'GET /error?username=yoshi 500 in 0ms',
         'timestamp'            => 1_450_150_205.123,
         'level'                => 3,
         '_type'                => 'request',
@@ -126,7 +126,7 @@ RSpec.shared_examples 'request logger' do
       expect(json).to match(
         'version'              => '1.1',
         'host'                 => 'bird.example.com',
-        'short_message'        => 'GET /not_found',
+        'short_message'        => 'GET /not_found 404 in 0ms',
         'timestamp'            => 1_450_150_205.123,
         'level'                => 6,
         '_type'                => 'request',
@@ -156,7 +156,7 @@ RSpec.shared_examples 'request logger' do
 
     it 'filters the parameter from the message' do
       expect(json).to include(
-        'short_message' => 'GET /ok?password=[FILTERED]',
+        'short_message' => 'GET /ok?password=[FILTERED] 200 in 0ms',
       )
     end
   end

--- a/spec/unit/loga/rack/logger_spec.rb
+++ b/spec/unit/loga/rack/logger_spec.rb
@@ -19,7 +19,7 @@ describe Loga::Rack::Logger do
 
     before do
       allow(subject).to receive(:started_at).and_return(:timestamp)
-      allow(subject).to receive(:duration_in_ms).with(any_args).and_return(:duration)
+      allow(subject).to receive(:duration_in_ms).with(any_args).and_return(5)
     end
 
     it 'instantiates a Loga::Event' do
@@ -33,11 +33,11 @@ describe Loga::Rack::Logger do
             'request_id' => nil,
             'request_ip' => nil,
             'user_agent' => nil,
-            'duration'   => :duration,
+            'duration'   => 5,
           },
         },
         exception: logged_exception,
-        message:   'GET /about_us?limit=1',
+        message:   %r{^GET \/about_us\?limit=1 #{response_status} in \d+ms$},
         timestamp: :timestamp,
         type:      'request',
       )


### PR DESCRIPTION
Provide additional information such as status and duration in the message.

```
# Before
GET /hello
# After
GET /hello 200 in 5ms
```
