### PR TITLE
Guard against Encoding::UndefinedConversionError

### DIFF
--- a/lib/loga/event.rb
+++ b/lib/loga/event.rb
@@ -5,9 +5,17 @@ module Loga
     def initialize(opts = {})
       @data      = opts[:data]
       @exception = opts[:exception]
-      @message   = opts[:message].to_s
+      @message   = safe_encode(opts[:message])
       @timestamp = opts[:timestamp]
       @type      = opts[:type]
+    end
+
+    private
+
+    # Guard against Encoding::UndefinedConversionError
+    # http://stackoverflow.com/questions/13003287/encodingundefinedconversionerror
+    def safe_encode(text)
+      text.to_s.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?')
     end
   end
 end

--- a/lib/loga/formatter.rb
+++ b/lib/loga/formatter.rb
@@ -37,12 +37,12 @@ module Loga
 
     private
 
-    def build_event(time, data)
-      event = case data
+    def build_event(time, message)
+      event = case message
               when Loga::Event
-                data
+                message
               else
-                Loga::Event.new(message: data.to_s)
+                Loga::Event.new(message: message)
               end
 
       event.timestamp ||= time

--- a/spec/unit/loga/event_spec.rb
+++ b/spec/unit/loga/event_spec.rb
@@ -2,23 +2,18 @@ require 'spec_helper'
 
 RSpec.describe Loga::Event do
   describe 'initialize' do
-    let(:options) { {} }
-
-    context 'when initialized with an empty hash' do
-      it 'accepts an optional hash' do
-        expect(described_class.new(options)).to be_a(Loga::Event)
+    context 'no message is passed' do
+      it 'sets message to an empty string' do
+        expect(subject.message).to eq ''
       end
     end
 
-    context 'when initialized with a hash including a message' do
-      let(:message) {  double(:message) }
-      let(:options) {  { message: message } }
+    context 'message is passed' do
+      let(:message) { "stuff \xC2".force_encoding 'ASCII-8BIT' }
+      let(:subject) { described_class.new message: message }
 
-      before { allow(message).to receive(:to_s) }
-
-      it 'calls to_s on the message' do
-        expect(message).to receive(:to_s)
-        described_class.new(options)
+      it 'sanitizes the input to be UTF-8 convertable' do
+        expect(subject.message.to_json).to eq '"stuff ?"'
       end
     end
   end


### PR DESCRIPTION
Because otherwise loga fails the application on an input that does not
convert to UTF-8.
