### PR TITLE
Fix warning when detecting git

### DIFF
--- a/lib/loga/configuration.rb
+++ b/lib/loga/configuration.rb
@@ -53,7 +53,7 @@ module Loga
       end
 
       def self.binary_available?
-        system 'which -s git'
+        system 'which git'
       end
 
       def self.fetch_revision


### PR DESCRIPTION
The which switch `-s` was only working for a BSD OS and was outputting warnings when deploying.

Devs: @Antti @FraDim
