### PR TITLE
Concatenate tags into String instead of Array to allow Graylog search

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Loga.logger.info('Hello World')
   "level":             6,
   "_service.name":     "marketplace",
   "_service.version":  "v1.0.0",
-  "_tags":             []
+  "_tags":             ""
 }
 ```
 

--- a/lib/loga/formatter.rb
+++ b/lib/loga/formatter.rb
@@ -97,7 +97,7 @@ module Loga
           name:    @service_name,
           version: @service_version,
         },
-        tags: current_tags,
+        tags: current_tags.join(' '),
       }
     end
   end

--- a/lib/loga/version.rb
+++ b/lib/loga/version.rb
@@ -1,3 +1,3 @@
 module Loga
-  VERSION = '1.1.1'.freeze
+  VERSION = '1.2.1'.freeze
 end

--- a/spec/fixtures/rails32/config/application.rb
+++ b/spec/fixtures/rails32/config/application.rb
@@ -60,7 +60,7 @@ module Rails32
     # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
     # parameters by using an attr_accessible or attr_protected declaration.
     # config.active_record.whitelist_attributes = true
-    config.log_tags = [:uuid]
+    config.log_tags = [ :uuid, 'TEST_TAG' ]
     config.loga.configure do |loga|
       loga.service_name = 'hello_world_app'
       loga.service_version = '1.0'

--- a/spec/fixtures/rails40/config/application.rb
+++ b/spec/fixtures/rails40/config/application.rb
@@ -26,7 +26,7 @@ module Rails40
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
-    config.log_tags = [:uuid]
+    config.log_tags = [ :uuid, 'TEST_TAG' ]
     config.loga.configure do |loga|
       loga.service_name = 'hello_world_app'
       loga.service_version = '1.0'

--- a/spec/integration/sinatra_spec.rb
+++ b/spec/integration/sinatra_spec.rb
@@ -24,7 +24,7 @@ describe 'Rack request logger with Sinatra', timecop: true do
       set :show_exceptions, false
 
       use Loga::Rack::RequestId
-      use Loga::Rack::Logger, Loga.logger, [:uuid]
+      use Loga::Rack::Logger, Loga.logger, [:uuid, 'TEST_TAG']
 
       error do
         status 500

--- a/spec/support/request_spec.rb
+++ b/spec/support/request_spec.rb
@@ -22,7 +22,7 @@ RSpec.shared_examples 'request logger' do
         '_request.status'     => 200,
         '_request.request_id' => '471a34dc',
         '_request.duration'   => 0,
-        '_tags'               => ['471a34dc'],
+        '_tags'               => '471a34dc TEST_TAG',
       )
     end
   end
@@ -52,7 +52,7 @@ RSpec.shared_examples 'request logger' do
         '_request.status'     => 200,
         '_request.request_id' => '471a34dc',
         '_request.duration'   => 0,
-        '_tags'               => ['471a34dc'],
+        '_tags'               => '471a34dc TEST_TAG',
       )
     end
 
@@ -83,7 +83,7 @@ RSpec.shared_examples 'request logger' do
         '_request.status'     => 302,
         '_request.request_id' => '471a34dc',
         '_request.duration'   => 0,
-        '_tags'               => ['471a34dc'],
+        '_tags'               => '471a34dc TEST_TAG',
       )
     end
   end
@@ -114,7 +114,7 @@ RSpec.shared_examples 'request logger' do
         '_exception.klass'     => 'NoMethodError',
         '_exception.message'   => "undefined method `name' for nil:NilClass",
         '_exception.backtrace' => be_a(String),
-        '_tags'               => ['471a34dc'],
+        '_tags'               => '471a34dc TEST_TAG',
       )
     end
   end
@@ -140,7 +140,7 @@ RSpec.shared_examples 'request logger' do
         '_request.status'      => 404,
         '_request.request_id'  => '471a34dc',
         '_request.duration'    => 0,
-        '_tags'               => ['471a34dc'],
+        '_tags'               => '471a34dc TEST_TAG',
       )
     end
   end

--- a/spec/unit/loga/formatter_spec.rb
+++ b/spec/unit/loga/formatter_spec.rb
@@ -26,7 +26,7 @@ describe Loga::Formatter do
     it 'includes Loga additional fields' do
       expect(json).to include('_service.name'    => service_name,
                               '_service.version' => service_version,
-                              '_tags'            => [])
+                              '_tags'            => '')
     end
 
     it 'outputs the timestamp in seconds since UNIX epoch' do


### PR DESCRIPTION
### Description

It isn't possible to search within Array structures in GrayLog. This is problematic when multiple tags are logged.
Now tags are saved in a single String which improves searching.
