### PR TITLE
Disable ActionDispatch::DebugExceptions

### DIFF
--- a/lib/loga/ext/rails/rack/debug_exceptions.rb
+++ b/lib/loga/ext/rails/rack/debug_exceptions.rb
@@ -1,0 +1,8 @@
+module ActionDispatch
+  class DebugExceptions
+    private
+
+    def logger(_request)
+    end
+  end
+end

--- a/lib/loga/railtie.rb
+++ b/lib/loga/railtie.rb
@@ -63,6 +63,7 @@ module Loga
         insert_loga_rack_logger
         disable_rails_rack_logger
         insert_exceptions_catcher
+        disable_action_dispatch_debug_exceptions
       end
 
       private
@@ -86,6 +87,10 @@ module Loga
         when 3 then require 'loga/ext/rails/rack/logger3.rb'
         when 4 then require 'loga/ext/rails/rack/logger4.rb'
         end
+      end
+
+      def disable_action_dispatch_debug_exceptions
+        require 'loga/ext/rails/rack/debug_exceptions.rb'
       end
 
       def insert_loga_rack_logger

--- a/lib/loga/version.rb
+++ b/lib/loga/version.rb
@@ -1,3 +1,3 @@
 module Loga
-  VERSION = '1.2.1'.freeze
+  VERSION = '1.3.0'.freeze
 end

--- a/spec/integration/rails/request_spec.rb
+++ b/spec/integration/rails/request_spec.rb
@@ -39,4 +39,12 @@ describe 'Integration with Rails', timecop: true do
       expect(action_view_notifications).to be_empty
     end
   end
+
+  describe 'when request causes ActionDispatch 404' do
+    it 'does not log ActionDispatch::DebugExceptions' do
+      get '/not_found', {}, 'HTTP_X_REQUEST_ID' => '471a34dc'
+      expect(json_entries.count).to eq(1)
+      expect(json['short_message']).to eq('GET /not_found 404 in 0ms')
+    end
+  end
 end


### PR DESCRIPTION
Disables ActionDispatch::DebugExceptions's `logger` to prevent duplicate exception logging.

Rails 4 [source](https://github.com/rails/rails/blob/v4.2.7.1/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb#L79-L98)
Rails 5 [source](https://github.com/rails/rails/blob/v5.0.0/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb#L149-L173)
