### PR TITLE
Remove Loga::Event#inspect that was aliased to #to_s

### DIFF
--- a/lib/loga/event.rb
+++ b/lib/loga/event.rb
@@ -19,8 +19,6 @@ module Loga
       output.join("\n")
     end
 
-    alias inspect to_s
-
     private
 
     # Guard against Encoding::UndefinedConversionError


### PR DESCRIPTION
This helps in debugging/testing in the console. Usually you want to know
whether you have a string or loga event in e.g. the logger and what are
its attributes.