### PR TITLE
Release Loga v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.1.0]
 ## [2.1.0.pre.1]
 ### Changed
 - Replace `ActiveSupport::Logger::SimpleFormatter` with `Loga::Formatters::SimpleFormatter`
@@ -47,8 +48,9 @@ when using simple format. The formatter adds level, timestamp, pid and tags prep
 ### Changed
 - Silence ActionDispatch::DebugExceptions' logger
 
+[2.1.0]: https://github.com/FundingCircle/loga/compare/v2.0.0...v2.0.0
 [2.1.0.pre.1]: https://github.com/FundingCircle/loga/compare/v2.0.0...v2.1.0.pre.1
-[2.0.0]: https://github.com/FundingCircle/loga/compare/v2.0.0.pre.3...v2.0.0
+[2.0.0]: https://github.com/FundingCircle/loga/compare/v1.4.0...v2.0.0
 [2.0.0.pre.3]: https://github.com/FundingCircle/loga/compare/v2.0.0.pre.2...v2.0.0.pre.3
 [2.0.0.pre.2]: https://github.com/FundingCircle/loga/compare/v2.0.0.pre1...v2.0.0.pre.2
 [2.0.0.pre1]: https://github.com/FundingCircle/loga/compare/v1.4.0...v2.0.0.pre1

--- a/lib/loga/version.rb
+++ b/lib/loga/version.rb
@@ -1,3 +1,3 @@
 module Loga
-  VERSION = '2.1.0.pre.1'.freeze
+  VERSION = '2.1.0'.freeze
 end


### PR DESCRIPTION
### Changed
- Replace `ActiveSupport::Logger::SimpleFormatter` with `Loga::Formatters::SimpleFormatter`
when using simple format. The formatter adds level, timestamp, pid and tags prepended to the message
