### PR TITLE
Add Rack ENV exception location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.1.2] - 2016-12-08
+### Fixed
+- `Loga::Rack::Logger` looks into `env['rack.exception']` for exceptions
+
 ## [2.1.1] - 2016-12-02
 ### Fixed
 - Encoding error when converting uploaded file to JSON
@@ -53,6 +57,7 @@ when using simple format. The formatter adds level, timestamp, pid and tags prep
 ### Changed
 - Silence ActionDispatch::DebugExceptions' logger
 
+[2.1.2]: https://github.com/FundingCircle/loga/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/FundingCircle/loga/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/FundingCircle/loga/compare/v2.0.0...v2.1.0
 [2.1.0.pre.1]: https://github.com/FundingCircle/loga/compare/v2.0.0...v2.1.0.pre.1

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ opposed to a `ActionDispatch::Request`.
 With Sinatra Loga needs to be configured manually:
 
 ```ruby
+# config.ru
+require 'sinatra/base'
 require 'loga'
 
 Loga.configure(
@@ -116,11 +118,19 @@ Loga.configure(
   tags: [:uuid],
 )
 
+class MyApp < Sinatra::Base
+  set :logging, false # suppress Sinatra request logger
+
+  get '/' do
+    Loga.logger.info('Everything is Awesome!')
+    'Hello World!'
+  end
+end
+
 use Loga::Rack::RequestId
 use Loga::Rack::Logger
 
-use MyApp
-run Sinatra::Application
+run MyApp
 ```
 
 You can now use `Loga.logger` or assign it to your existing logger.

--- a/lib/loga/rack/logger.rb
+++ b/lib/loga/rack/logger.rb
@@ -80,7 +80,8 @@ module Loga
       end
 
       def exception
-        env['loga.exception'] || env['action_dispatch.exception'] || env['sinatra.error']
+        env['loga.exception'] || env['action_dispatch.exception'] ||
+          env['sinatra.error'] || env['rack.exception']
       end
 
       def filter_exceptions

--- a/lib/loga/version.rb
+++ b/lib/loga/version.rb
@@ -1,3 +1,3 @@
 module Loga
-  VERSION = '2.1.1'.freeze
+  VERSION = '2.1.2'.freeze
 end

--- a/spec/unit/loga/rack/logger_spec.rb
+++ b/spec/unit/loga/rack/logger_spec.rb
@@ -96,6 +96,15 @@ describe Loga::Rack::Logger do
       include_examples 'logs the event', level: :info
     end
 
+    context 'when the exception is on rack.exception', focus: true do
+      let(:response_status)  { 500 }
+      let(:exception)        { StandardError }
+      let(:logged_exception) { exception }
+      let(:options)          { { 'rack.exception' => exception } }
+
+      include_examples 'logs the event', level: :error
+    end
+
     context 'when no exception is raised' do
       include_examples 'logs the event', level: :info
     end


### PR DESCRIPTION
### Fixed
- `Loga::Rack::Logger` looks into `env['rack.exception']` for exceptions