### PR TITLE
Add Ruby 2.4.1 to test matrix

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -2,8 +2,8 @@ appraise 'rails32' do
   gem 'rails', '~> 3.2.0'
 end
 
-appraise 'rails40' do
-  gem 'rails', '~> 4.0.0'
+appraise 'rails42' do
+  gem 'rails', '~> 4.2.0'
 end
 
 appraise 'sinatra14' do

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,9 @@
 dependencies:
   override:
-    - rvm-exec 2.2.5 bundle install -j 4
-    - rvm-exec 2.2.5 bundle exec appraisal install -j 4
-    - rvm-exec 2.3.1 bundle install -j 4
-    - rvm-exec 2.3.1 bundle exec appraisal install -j 4
+    - rvm-exec 2.2.5 bundle install --jobs 4
+    - rvm-exec 2.2.5 bundle exec appraisal install --jobs 4
+    - rvm-exec 2.3.1 bundle install --jobs 4
+    - rvm-exec 2.3.1 bundle exec appraisal install --jobs 4
 test:
   override:
     - RACK_ENV=development rvm-exec 2.2.5 bundle exec appraisal rspec

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ test:
     - rvm-exec 2.3.1 bundle exec rubocop
     - rvm-exec 2.3.1 bundle exec codeclimate-test-reporter
 deployment:
-  gemfury:
+  rubygems:
     tag: /^v\d.+/
     owner: FundingCircle
     commands:

--- a/circle.yml
+++ b/circle.yml
@@ -4,14 +4,18 @@ dependencies:
     - rvm-exec 2.2.5 bundle exec appraisal install --jobs 4
     - rvm-exec 2.3.1 bundle install --jobs 4
     - rvm-exec 2.3.1 bundle exec appraisal install --jobs 4
+    - rvm-exec 2.4.1 bundle install --jobs 4
+    - rvm-exec 2.4.1 bundle exec appraisal install --jobs 4
 test:
   override:
     - RACK_ENV=development rvm-exec 2.2.5 bundle exec appraisal rspec
     - RACK_ENV=production  rvm-exec 2.2.5 bundle exec appraisal rspec
     - RACK_ENV=development rvm-exec 2.3.1 bundle exec appraisal rspec
     - RACK_ENV=production  rvm-exec 2.3.1 bundle exec appraisal rspec
-    - rvm-exec 2.3.1 bundle exec rubocop
-    - rvm-exec 2.3.1 bundle exec codeclimate-test-reporter
+    - RACK_ENV=development rvm-exec 2.4.1 bundle exec appraisal rspec
+    - RACK_ENV=production  rvm-exec 2.4.1 bundle exec appraisal rspec
+    - rvm-exec 2.4.1 bundle exec rubocop
+    - rvm-exec 2.4.1 bundle exec codeclimate-test-reporter
 deployment:
   rubygems:
     tag: /^v\d.+/

--- a/spec/fixtures/rails42.rb
+++ b/spec/fixtures/rails42.rb
@@ -10,6 +10,7 @@ class Dummy < Rails::Application
   config.secret_key_base = '2624599ca9ab3cf3823626240138a128118a87683bf03ab8f155844c33b3cd8cbbfa3ef5e29db6f5bd182f8bd4776209d9577cfb46ac51bfd232b00ab0136b24'
   config.session_store :cookie_store, key: '_rails32_session'
 
+  config.log_level = :info
   config.log_tags = [ :uuid, 'TEST_TAG' ]
   config.loga = {
     device: STREAM,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,12 @@
+require 'simplecov'
+SimpleCov.start
+
 require 'pry'
 require 'support/gethostname_shared'
 require 'support/helpers'
 require 'support/request_spec'
 require 'support/timecop_shared'
 require 'rack/test'
-require 'simplecov'
-
-SimpleCov.start
 
 case ENV['BUNDLE_GEMFILE']
 when /rails/


### PR DESCRIPTION
💁  These changes add Ruby 2.4.1 to test matrix's Ruby versions.