### PR TITLE
Fix broken test suite

### DIFF
--- a/loga.gemspec
+++ b/loga.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 2.3.8'
   spec.add_dependency 'rack'
 
-  spec.add_development_dependency 'appraisal', '~> 2.0.2'
+  spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rack-test'

--- a/spec/integration/sinatra_spec.rb
+++ b/spec/integration/sinatra_spec.rb
@@ -21,7 +21,7 @@ class MySinatraApp < Sinatra::Base
   end
 end
 
-RSpec.describe 'Structured logging with Sinatra', timecop: true do
+RSpec.describe 'Structured logging with Sinatra', :with_hostname, :timecop do
   let(:io) { StringIO.new }
   let(:format) {}
   before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,12 @@
 require 'pry'
+require 'support/gethostname_shared'
 require 'support/helpers'
-require 'support/timecop_shared'
 require 'support/request_spec'
+require 'support/timecop_shared'
 require 'rack/test'
 require 'simplecov'
 
 SimpleCov.start
-
-class Socket
-  def self.gethostname
-    'bird.example.com'
-  end
-end
 
 case ENV['BUNDLE_GEMFILE']
 when /rails/

--- a/spec/support/gethostname_shared.rb
+++ b/spec/support/gethostname_shared.rb
@@ -1,0 +1,7 @@
+shared_context 'gethostname', with_hostname: true do
+  let(:hostname) { 'bird.example.com' }
+
+  before do
+    allow(Socket).to receive(:gethostname).and_return(hostname)
+  end
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -9,8 +9,4 @@ module Helpers
   def time_anchor_unix
     BigDecimal.new('1450150205.123')
   end
-
-  def hostname_anchor
-    'bird.example.com'
-  end
 end

--- a/spec/unit/loga/configuration_spec.rb
+++ b/spec/unit/loga/configuration_spec.rb
@@ -20,12 +20,12 @@ describe Loga::Configuration do
       allow(Loga::ServiceVersionStrategies).to receive(:call).and_return('unknown.sha')
     end
 
-    context 'defaults' do
+    context 'defaults', with_hostname: true do
       specify { expect(subject.device).to eq(STDOUT) }
       specify { expect(subject.filter_exceptions).to eq(framework_exceptions) }
       specify { expect(subject.filter_parameters).to eq([]) }
       specify { expect(subject.format).to eq(:simple) }
-      specify { expect(subject.host).to eq(hostname_anchor) }
+      specify { expect(subject.host).to eq(hostname) }
       specify { expect(subject.level).to eq(:info) }
       specify { expect(subject.service_name).to eq('hello_world_app') }
       specify { expect(subject.service_version).to eq('unknown.sha') }


### PR DESCRIPTION
Use shared context stub instead of overriding `Socket.gethostname`.