### PR TITLE
Improve CircleCI 2.0 caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,15 +7,17 @@ defaults: &defaults
     - &restore_gems
       restore_cache:
         keys:
-          - gems-{{ checksum "Gemfile" }}-{{ checksum "Appraisals"}}-{{ .Environment.CIRCLE_JOB }}
+          - v2-gems-{{ checksum "Gemfile" }}-{{ checksum "Appraisals"}}-{{ .Environment.CIRCLE_JOB }}
+          - v2-gems-{{ checksum "Gemfile" }}
     - &bundle_install
       run: bundle install --jobs 4 --path=vendor/bundle --retry 3
     - run: bundle exec appraisal install
     - &cache_gems
       save_cache:
-        key: gems-{{ checksum "Gemfile" }}-{{ checksum "Appraisals"}}-{{ .Environment.CIRCLE_JOB }}
+        key: v2-gems-{{ checksum "Gemfile" }}-{{ checksum "Appraisals"}}-{{ .Environment.CIRCLE_JOB }}
         paths:
-          - vendor/bundle
+          - ~/loga/gemfiles/vendor/bundle
+          - ~/loga/vendor/bundle
     - run: RACK_ENV=development bundle exec appraisal rspec
     - run: RACK_ENV=production bundle exec appraisal rspec
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ tmp
 mkmf.log
 spec/fixtures/**/*.log
 gemfiles/*.lock
+vendor/bundle

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,8 @@
 AllCops:
   Exclude:
-    - 'spec/fixtures/**/*'
     - '*.gemspec'
+    - 'spec/fixtures/**/*'
+    - 'vendor/bundle/**/*'
 
 Documentation:
   Enabled: false


### PR DESCRIPTION
- Add `vendor/bundle` to Rubocop exclusion list
- Ensure all gems are cached

![image](https://user-images.githubusercontent.com/1334474/38708838-05bed79a-3eb0-11e8-8322-a3aea6d3e19b.png)
