### PR TITLE
Fix the Publish to rubygems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,7 @@ jobs:
       - deploy:
           name: Publish to rubygems
           command: |
+            mkdir ~/.gem
             echo ":rubygems_api_key: $RUBYGEMS_API_KEY" >  ~/.gem/credentials
             chmod 0600 ~/.gem/credentials
             gem push $CIRCLE_PROJECT_REPONAME-$(echo $CIRCLE_TAG | sed -e 's/v//').gem


### PR DESCRIPTION
There is no `~/.gem` folder.

I've published the v2.2.0 manually https://rubygems.org/gems/loga/versions/2.2.0