### PR TITLE
Adds new option hide_pii that hides emails being logged to info

### DIFF
--- a/lib/loga/configuration.rb
+++ b/lib/loga/configuration.rb
@@ -15,9 +15,10 @@ module Loga
     ].freeze
 
     attr_accessor :device, :filter_exceptions, :filter_parameters,
-                  :host, :level, :service_version, :sync, :tags
+                  :host, :level, :service_version, :sync, :tags, :hide_pii
     attr_reader :logger, :format, :service_name
 
+    # rubocop:disable Metrics/MethodLength
     def initialize(user_options = {}, framework_options = {})
       options = default_options.merge(framework_options)
                                .merge(environment_options)
@@ -33,11 +34,13 @@ module Loga
       self.service_version   = options[:service_version] || ServiceVersionStrategies.call
       self.sync              = options[:sync]
       self.tags              = options[:tags]
+      self.hide_pii          = options[:hide_pii]
 
       validate
 
       @logger = initialize_logger
     end
+    # rubocop:enable Metrics/MethodLength
 
     def format=(name)
       @format = name.to_s.to_sym
@@ -68,6 +71,7 @@ module Loga
         level:             :info,
         sync:              true,
         tags:              [],
+        hide_pii:          true,
       }
     end
 

--- a/lib/loga/log_subscribers/action_mailer.rb
+++ b/lib/loga/log_subscribers/action_mailer.rb
@@ -9,7 +9,11 @@ module Loga
         recipients = event.payload[:to].join(',')
         unique_id  = event.payload[:unique_id]
         duration   = event.duration.round(1)
-        message = "#{mailer}: Sent mail to #{recipients} in (#{duration}ms)"
+        message    = ''.tap do |string|
+          string << "#{mailer}: Sent mail"
+          string << " to #{recipients}" unless hide_pii?
+          string << " in (#{duration}ms)"
+        end
 
         loga_event = Event.new(
           data: { mailer: mailer, unique_id: unique_id },
@@ -41,10 +45,15 @@ module Loga
         from      = event.payload[:from]
         mailer    = event.payload[:mailer]
         unique_id = event.payload[:unique_id]
+        message   = ''.tap do |string|
+          string << 'Received mail'
+          string << " from #{from}" unless hide_pii?
+          string << " in (#{event.duration.round(1)}ms)"
+        end
 
         loga_event = Event.new(
           data: { mailer: mailer, unique_id: unique_id },
-          message: "Received mail #{from} in (#{event.duration.round(1)}ms)",
+          message: message,
           type: 'action_mailer',
         )
 
@@ -53,6 +62,10 @@ module Loga
 
       def logger
         Loga.logger
+      end
+
+      def hide_pii?
+        Loga.configuration.hide_pii
       end
     end
   end

--- a/spec/integration/rails/action_mailer_spec.rb
+++ b/spec/integration/rails/action_mailer_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Loga::LogSubscribers::ActionMailer, if: Rails.env.production? do
     it 'has the proper payload for message delivery' do
       FakeMailer.send_email
 
-      message_pattern = /^FakeMailer: Sent mail to user@example.com in \(*/
+      message_pattern = /^FakeMailer: Sent mail \(*/
       expect(last_log_entry['short_message']).to match(message_pattern)
     end
 


### PR DESCRIPTION
New configuration option added called `hide_pii` which defaults to true.

This option hides users email addresses from being logged out to `info`.

/cc @FundingCircle/gdpr-engineering 