### PR TITLE
Fix the duration in the sidekiq instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.4.0] - 2019-09-03
+### Fixed
+- `duration` in the `sidekiq` integration is now calculated correctly
+### Added
+- Add build for ruby 2.6
+### Removed
+- Remove build for ruby 2.2
+
 ## [2.3.1] - 2019-05-14
 ### Added
 New configuration option `hide_pii` which defaults to `true` to hide email addresses in logs that get generate when an email is sent through action_mailer

--- a/lib/loga/sidekiq/job_logger.rb
+++ b/lib/loga/sidekiq/job_logger.rb
@@ -9,14 +9,16 @@ module Loga
 
       EVENT_TYPE = 'sidekiq'.freeze
 
-      attr_reader :started_at, :data
+      def started_at
+        @started_at ||= Time.now
+      end
 
-      def initialize
-        @started_at = Time.now
-        @data = {}
+      def data
+        @data ||= {}
       end
 
       def call(item, _queue)
+        reset_data
         yield
       rescue Exception => ex # rubocop:disable Lint/RescueException
         data['exception'] = ex
@@ -28,6 +30,11 @@ module Loga
       end
 
       private
+
+      def reset_data
+        @data = {}
+        @started_at = Time.now
+      end
 
       def assign_data(item)
         data['created_at']  = item['created_at']

--- a/lib/loga/version.rb
+++ b/lib/loga/version.rb
@@ -1,3 +1,3 @@
 module Loga
-  VERSION = '2.3.1'.freeze
+  VERSION = '2.4.0'.freeze
 end


### PR DESCRIPTION
This PR is based on https://github.com/FundingCircle/loga/pull/118 as the ruby 2.2 build fails.

## Problem

The logger keeps increasing the duration to e.g 292027923ms numbers ->
most probably it is created only once.

## Solution

Reset the `@data` / `@start_at` time variables on every call.