### PR TITLE
Add support for rails 6

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -24,6 +24,12 @@ appraise 'rails52' do
   gem 'rails', '~> 5.2.0'
 end
 
+if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('2.5.0')
+  appraise 'rails60' do
+    gem 'rails', '~> 6.0.0'
+  end
+end
+
 appraise 'sidekiq51' do
   gem 'sidekiq', '~> 5.1.0'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.5.0] - 2019-11-12
+### Added
+- Add support for rails 6
+
 ## [2.4.0] - 2019-09-03
 ### Fixed
 - `duration` in the `sidekiq` integration is now calculated correctly

--- a/lib/loga/railtie.rb
+++ b/lib/loga/railtie.rb
@@ -125,7 +125,7 @@ module Loga
       def silence_rails_rack_logger
         case Rails::VERSION::MAJOR
         when 3    then require 'loga/ext/rails/rack/logger3.rb'
-        when 4..5 then require 'loga/ext/rails/rack/logger.rb'
+        when 4..6 then require 'loga/ext/rails/rack/logger.rb'
         else
           raise Loga::ConfigurationError,
                 "Rails #{Rails::VERSION::MAJOR} is unsupported"

--- a/lib/loga/version.rb
+++ b/lib/loga/version.rb
@@ -1,3 +1,3 @@
 module Loga
-  VERSION = '2.4.0'.freeze
+  VERSION = '2.5.0'.freeze
 end

--- a/spec/fixtures/rails60.rb
+++ b/spec/fixtures/rails60.rb
@@ -1,0 +1,80 @@
+require 'action_controller/railtie'
+require 'action_mailer/railtie'
+
+Bundler.require(*Rails.groups)
+
+STREAM = StringIO.new unless defined?(STREAM)
+
+class Dummy < Rails::Application
+  config.eager_load = true
+  config.filter_parameters += [:password]
+  config.secret_key_base = '2624599ca9ab3cf3823626240138a128118a87683bf03ab8f155844c33b3cd8cbbfa3ef5e29db6f5bd182f8bd4776209d9577cfb46ac51bfd232b00ab0136b24'
+  config.session_store :cookie_store, key: '_rails60_session'
+
+  config.log_tags = [:uuid, 'TEST_TAG']
+  config.loga = {
+    device: STREAM,
+    host: 'bird.example.com',
+    service_name: 'hello_world_app',
+    service_version: '1.0',
+  }
+  config.action_mailer.delivery_method = :test
+end
+
+class ApplicationController < ActionController::Base
+  include Rails.application.routes.url_helpers
+  protect_from_forgery with: :null_session
+
+  def ok
+    render plain: 'Hello Rails'
+  end
+
+  def error
+    nil.name
+  end
+
+  def show
+    render json: params
+  end
+
+  def create
+    render json: params
+  end
+
+  def new
+    redirect_to :ok
+  end
+
+  def update
+    @id = params[:id]
+    render '/user'
+  end
+end
+
+class FakeMailer < ActionMailer::Base
+  default from: 'notifications@example.com'
+
+  def self.send_email
+    basic_mail.deliver_now
+  end
+
+  def basic_mail
+    mail(
+      to: 'user@example.com',
+      subject: 'Welcome to My Awesome Site',
+      body: 'Banana muffin',
+      content_type: 'text/html',
+    )
+  end
+end
+
+Dummy.routes.append do
+  get 'ok'        => 'application#ok'
+  get 'error'     => 'application#error'
+  get 'show'      => 'application#show'
+  post 'users'    => 'application#create'
+  get 'new'       => 'application#new'
+  put 'users/:id' => 'application#update'
+end
+
+Dummy.initialize!


### PR DESCRIPTION
Support rails 6

This commit modifies the railtie for loga to support rails 6. Our monkey patch for Rails::Rack::Logger is still valid as there has been no changes for this file between rails 5.2 and rails 6.0 in the upstream.

This commit also ensures the test suite runs against rails 6 for ruby versions greater than or equal to 2.5 which is the ruby version required for rails 6.

This should help users who are upgrading to rails 6 will be coming across a "Loga::ConfigurationError: Rails 6 is unsupported" error.