### PR TITLE
Fix sidekiq 6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,10 @@ jobs:
     docker:
       - image: circleci/ruby:2.6
     <<: *test_build
+  ruby-2.7:
+    docker:
+      - image: circleci/ruby:2.7
+    <<: *test_build
   rubocop:
     <<: *basic_build
     steps:
@@ -135,6 +139,12 @@ workflows:
               only: /.*/
           requires:
             - build
+      - ruby-2.7:
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - build
       - upload-coverage:
           filters:
             tags:
@@ -144,6 +154,7 @@ workflows:
             - ruby-2.4
             - ruby-2.5
             - ruby-2.6
+            - ruby-2.7
       - push-to-rubygems:
           filters:
             tags:
@@ -156,3 +167,4 @@ workflows:
             - ruby-2.4
             - ruby-2.5
             - ruby-2.6
+            - ruby-2.7

--- a/Appraisals
+++ b/Appraisals
@@ -8,20 +8,22 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.0')
   end
 end
 
-appraise 'rails42' do
-  gem 'rails', '~> 4.2.0'
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0')
+  appraise 'rails42' do
+    gem 'rails', '~> 4.2.0'
+  end
+
+  appraise 'rails50' do
+    gem 'rails', '~> 5.0.0'
+  end
+
+  appraise 'rails52' do
+    gem 'rails', '~> 5.2.0'
+  end
 end
 
 appraise 'sinatra14' do
   gem 'sinatra', '~> 1.4.0'
-end
-
-appraise 'rails50' do
-  gem 'rails', '~> 5.0.0'
-end
-
-appraise 'rails52' do
-  gem 'rails', '~> 5.2.0'
 end
 
 if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('2.5.0')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.5.3] - 2020-10-27
+### Fixed
+- Support for sidekiq 6 - previous versions were causing sidekiq to crash with `Internal exception!`
+
 ## [2.5.2] - 2020-10-21
 ### Fixed
 - Support for sidekiq 6

--- a/lib/loga/configuration.rb
+++ b/lib/loga/configuration.rb
@@ -79,6 +79,7 @@ module Loga
       { format: ENV['LOGA_FORMAT'].presence }.reject { |_, v| v.nil? }
     end
 
+    # Note: sidekiq 6 will extend the logger -> https://github.com/mperham/sidekiq/blob/v6.1.2/lib/sidekiq.rb#L210
     def initialize_logger
       device.sync      = sync
       logger           = Logger.new(device)

--- a/lib/loga/sidekiq.rb
+++ b/lib/loga/sidekiq.rb
@@ -1,13 +1,21 @@
-require 'loga/sidekiq/job_logger'
-
 module Loga
   module Sidekiq
     def self.configure_logging
       return unless defined?(::Sidekiq)
       return if Gem::Version.new(::Sidekiq::VERSION) < Gem::Version.new('5.0')
 
-      ::Sidekiq.configure_server do |config|
-        config.options[:job_logger] = Loga::Sidekiq::JobLogger
+      if Gem::Version.new(::Sidekiq::VERSION) < Gem::Version.new('6.0')
+        require 'loga/sidekiq5/job_logger'
+
+        ::Sidekiq.configure_server do |config|
+          config.options[:job_logger] = Loga::Sidekiq5::JobLogger
+        end
+      elsif Gem::Version.new(::Sidekiq::VERSION) < Gem::Version.new('7.0')
+        require 'loga/sidekiq6/job_logger'
+
+        ::Sidekiq.configure_server do |config|
+          config.options[:job_logger] = Loga::Sidekiq6::JobLogger
+        end
       end
 
       ::Sidekiq.logger = Loga.configuration.logger

--- a/lib/loga/sidekiq5/job_logger.rb
+++ b/lib/loga/sidekiq5/job_logger.rb
@@ -1,9 +1,7 @@
 module Loga
-  module Sidekiq
+  module Sidekiq5
     # The approach of using a custom job logger in sidekiq was introduced
     # in v5.0: https://github.com/mperham/sidekiq/pull/3235
-    # This job logger does not support logging for Sidekiq versions
-    # that are before 5.0
     class JobLogger
       include Loga::Utilities
 

--- a/lib/loga/sidekiq6/job_logger.rb
+++ b/lib/loga/sidekiq6/job_logger.rb
@@ -1,0 +1,47 @@
+require 'sidekiq/job_logger'
+
+module Loga
+  module Sidekiq6
+    class JobLogger < ::Sidekiq::JobLogger
+      EVENT_TYPE = 'sidekiq'.freeze
+
+      def call(item, _queue)
+        start = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+
+        yield
+
+        with_elapsed_time_context(start) do
+          loga_log(
+            message: "#{item['class']} with jid: '#{item['jid']}' done", item: item,
+          )
+        end
+      rescue Exception => e # rubocop:disable Lint/RescueException
+        with_elapsed_time_context(start) do
+          loga_log(
+            message: "#{item['class']} with jid: '#{item['jid']}' fail", item: item,
+            exception: e
+          )
+        end
+
+        raise
+      end
+
+      private
+
+      def loga_log(message:, item:, exception: nil)
+        data = {
+          'created_at'  => item['created_at'],
+          'enqueued_at' => item['enqueued_at'],
+          'jid'         => item['jid'],
+          'queue'       => item['queue'],
+          'retry'       => item['retry'],
+          'params'      => item['args'],
+          'class'       => item['class'],
+        }
+        data['exception'] = exception if exception
+
+        @logger.info(Event.new(type: EVENT_TYPE, message: message, data: data))
+      end
+    end
+  end
+end

--- a/lib/loga/sidekiq6/job_logger.rb
+++ b/lib/loga/sidekiq6/job_logger.rb
@@ -38,9 +38,12 @@ module Loga
           'params'      => item['args'],
           'class'       => item['class'],
         }
-        data['exception'] = exception if exception
-
-        @logger.info(Event.new(type: EVENT_TYPE, message: message, data: data))
+        if exception
+          data['exception'] = exception
+          @logger.warn(Event.new(type: EVENT_TYPE, message: message, data: data))
+        else
+          @logger.info(Event.new(type: EVENT_TYPE, message: message, data: data))
+        end
       end
     end
   end

--- a/lib/loga/version.rb
+++ b/lib/loga/version.rb
@@ -1,3 +1,3 @@
 module Loga
-  VERSION = '2.5.2'.freeze
+  VERSION = '2.5.3'.freeze
 end

--- a/loga.gemspec
+++ b/loga.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rack'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
-  spec.add_development_dependency 'bundler',   '~> 1.6'
+  spec.add_development_dependency 'bundler',   '>= 1.6'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'guard',         '~> 2.13'
   spec.add_development_dependency 'guard-rspec',   '~> 4.7.3'

--- a/spec/integration/sidekiq6_spec.rb
+++ b/spec/integration/sidekiq6_spec.rb
@@ -1,0 +1,164 @@
+require 'spec_helper'
+require 'timecop'
+require 'fakeredis'
+
+dummy_redis_config = ConnectionPool.new(size: 5) { Redis.new }
+
+Sidekiq.configure_client do |config|
+  config.redis = dummy_redis_config
+end
+
+Sidekiq.configure_server do |config|
+  config.redis = dummy_redis_config
+end
+
+class MySidekiqWorker
+  include Sidekiq::Worker
+
+  def perform(_name)
+    logger.info('Hello from MySidekiqWorker')
+  end
+end
+
+describe 'Sidekiq client logger' do
+  let(:mgr) do
+    # https://github.com/mperham/sidekiq/blob/v6.1.2/test/test_actors.rb#L58-L82
+    Class.new do
+      attr_reader :latest_error, :mutex, :cond
+
+      def initialize
+        @mutex = ::Mutex.new
+        @cond = ::ConditionVariable.new
+      end
+
+      def processor_died(_inst, err)
+        @latest_error = err
+
+        @mutex.synchronize { @cond.signal }
+      end
+
+      def processor_stopped(_inst)
+        @mutex.synchronize { @cond.signal }
+      end
+
+      def options
+        {
+          concurrency: 3,
+          queues: ['default'],
+          job_logger: Loga::Sidekiq6::JobLogger,
+        }.tap { |opts| opts[:fetch] = ::Sidekiq::BasicFetch.new(opts) }
+      end
+    end
+  end
+
+  let(:target) { StringIO.new }
+
+  def read_json_log(line:)
+    target.rewind
+    JSON.parse(target.each_line.drop(line - 1).first)
+  end
+
+  before do
+    Redis.current.flushall
+
+    Loga.reset
+
+    Loga.configure(
+      service_name: 'hello_world_app',
+      service_version: '1.0',
+      device: target,
+      format: :gelf,
+    )
+  end
+
+  it 'has the proper job logger' do
+    expect(Sidekiq.options[:job_logger]).to eq Loga::Sidekiq6::JobLogger
+  end
+
+  it 'has the proper logger for Sidekiq.logger' do
+    expect(Sidekiq.logger).to eq Loga.logger
+  end
+
+  it 'pushes a new element in the default queue' do
+    MySidekiqWorker.perform_async('Bob')
+
+    last_element = JSON.parse(Redis.current.lpop('queue:default'))
+
+    aggregate_failures do
+      expect(last_element['class']).to eq 'MySidekiqWorker'
+      expect(last_element['args']).to eq ['Bob']
+      expect(last_element['retry']).to eq true
+      expect(last_element['queue']).to eq 'default'
+    end
+  end
+
+  def test_log_from_worker(json_line)
+    aggregate_failures do
+      expect(json_line).to include(
+        '_class' => 'MySidekiqWorker',
+        '_service.name' => 'hello_world_app',
+        '_service.version' => '1.0',
+        '_tags' => '',
+        'level' => 6,
+        'version' => '1.1',
+        'short_message' => 'Hello from MySidekiqWorker',
+      )
+
+      %w[_jid timestamp host].each do |key|
+        expect(json_line).to have_key(key)
+      end
+
+      expect(json_line).not_to include('_duration')
+    end
+  end
+
+  def test_job_end_log(json_line) # rubocop:disable Metrics/MethodLength
+    aggregate_failures do
+      expect(json_line).to include(
+        '_queue' => 'default',
+        '_retry' => true,
+        '_params' => ['Bob'],
+        '_class' => 'MySidekiqWorker',
+        '_type' => 'sidekiq',
+        '_service.name' => 'hello_world_app',
+        '_service.version' => '1.0',
+        '_tags' => '',
+        'level' => 6,
+        'version' => '1.1',
+      )
+
+      %w[_created_at _enqueued_at _jid _duration timestamp host].each do |key|
+        expect(json_line).to have_key(key)
+      end
+
+      expect(json_line['_duration']).to be < 500
+      expect(json_line['short_message']).to match(/MySidekiqWorker with jid:*/)
+    end
+  end
+
+  it 'logs the job processing event' do
+    MySidekiqWorker.perform_async('Bob')
+
+    require 'sidekiq/processor'
+
+    sidekiq_manager = mgr.new
+    Sidekiq::Processor.new(sidekiq_manager, sidekiq_manager.options).start
+    sleep 0.5
+
+    test_log_from_worker(read_json_log(line: 1))
+    test_job_end_log(read_json_log(line: 2))
+
+    # This was a bug - the duration was constantly incresing based on when
+    # the logger was created. https://github.com/FundingCircle/loga/pull/117
+    #
+    # Test that after sleeping for few seconds the duration is still under 500ms
+    sleep 1
+
+    MySidekiqWorker.perform_async('Bob')
+
+    sleep 1
+
+    test_log_from_worker(read_json_log(line: 3))
+    test_job_end_log(read_json_log(line: 4))
+  end
+end

--- a/spec/integration/sidekiq_spec.rb
+++ b/spec/integration/sidekiq_spec.rb
@@ -66,45 +66,60 @@ describe 'Sidekiq client logger' do
     it 'has the proper logger Sidekiq::Logging.logger' do
       expect(Sidekiq::Logging.logger).to eq Loga.logger
     end
+  end
 
-    # https://github.com/mperham/sidekiq/blob/97363210b47a4f8a1d8c1233aaa059d6643f5040/test/test_actors.rb#L57-L79
-    let(:mgr) do
-      Class.new do
-        attr_reader :latest_error, :mutex, :cond
+  # https://github.com/mperham/sidekiq/blob/97363210b47a4f8a1d8c1233aaa059d6643f5040/test/test_actors.rb#L57-L79
+  let(:mgr) do
+    Class.new do
+      attr_reader :latest_error, :mutex, :cond
 
-        def initialize
-          @mutex = ::Mutex.new
-          @cond = ::ConditionVariable.new
-        end
+      def initialize
+        @mutex = ::Mutex.new
+        @cond = ::ConditionVariable.new
+      end
 
-        def processor_died(_inst, err)
-          @latest_error = err
+      def processor_died(_inst, err)
+        @latest_error = err
 
-          @mutex.synchronize { @cond.signal }
-        end
+        @mutex.synchronize { @cond.signal }
+      end
 
-        def processor_stopped(_inst)
-          @mutex.synchronize { @cond.signal }
-        end
+      def processor_stopped(_inst)
+        @mutex.synchronize { @cond.signal }
+      end
 
-        def options
-          {
-            concurrency: 3,
-            queues: ['default'],
-            job_logger: Loga::Sidekiq::JobLogger,
-          }
-        end
+      def options
+        {
+          concurrency: 3,
+          queues: ['default'],
+          job_logger: Loga::Sidekiq::JobLogger,
+        }
       end
     end
+  end
 
-    it 'logs the job processing event' do
-      MySidekiqWorker.perform_async('Bob')
+  it 'logs the job processing event' do
+    MySidekiqWorker.perform_async('Bob')
 
-      require 'sidekiq/processor'
+    require 'sidekiq/processor'
+
+    if ENV['BUNDLE_GEMFILE'] =~ /sidekiq51/
       Sidekiq::Processor.new(mgr.new).start
-      sleep 0.5
+    else
+      Sidekiq::Processor.new(
+        mgr.new,
+        {
+          fetch: Sidekiq::BasicFetch.new({:queues => ['default']}),
+          job_logger: Loga::Sidekiq::JobLogger,
+        }
+      ).start
+    end
+    sleep 0.5
 
-      expected_attributes = {
+    json_line = read_json_log(line: 1)
+
+    aggregate_failures do
+      expect(json_line).to include({
         '_queue'=> 'default',
         '_retry'=> true,
         '_params'=> ['Bob'],
@@ -115,33 +130,27 @@ describe 'Sidekiq client logger' do
         '_tags'=> '',
         'level'=> 6,
         'version'=> '1.1',
-      }
+      })
 
-      json_line = read_json_log(line: 1)
-
-      aggregate_failures do
-        expect(json_line).to include(expected_attributes)
-
-        %w[_created_at _enqueued_at _jid _duration timestamp host].each do |key|
-          expect(json_line).to have_key(key)
-        end
-
-        expect(json_line['short_message']).to match(/MySidekiqWorker with jid:*/)
+      %w[_created_at _enqueued_at _jid _duration timestamp host].each do |key|
+        expect(json_line).to have_key(key)
       end
 
-      # This was a bug - the duration was constantly incresing based on when
-      # the logger was created. https://github.com/FundingCircle/loga/pull/117
-      #
-      # Test that after sleeping for few seconds the duration is still under 500ms
-      sleep 1
-
-      MySidekiqWorker.perform_async('Bob')
-
-      sleep 1
-
-      json_line = read_json_log(line: 2)
-
-      expect(json_line['_duration']).to be < 500
+      expect(json_line['short_message']).to match(/MySidekiqWorker with jid:*/)
     end
+
+    # This was a bug - the duration was constantly incresing based on when
+    # the logger was created. https://github.com/FundingCircle/loga/pull/117
+    #
+    # Test that after sleeping for few seconds the duration is still under 500ms
+    sleep 1
+
+    MySidekiqWorker.perform_async('Bob')
+
+    sleep 1
+
+    json_line = read_json_log(line: 2)
+
+    expect(json_line['_duration']).to be < 500
   end
 end

--- a/spec/loga/sidekiq5/job_logger_spec.rb
+++ b/spec/loga/sidekiq5/job_logger_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Loga::Sidekiq::JobLogger do
+RSpec.describe Loga::Sidekiq5::JobLogger do
   subject(:job_logger) { described_class.new }
 
   let(:target) { StringIO.new }

--- a/spec/loga/sidekiq6/job_logger_spec.rb
+++ b/spec/loga/sidekiq6/job_logger_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
-require 'loga/sidekiq5/job_logger'
+require 'loga/sidekiq6/job_logger'
 
-RSpec.describe Loga::Sidekiq5::JobLogger do
+RSpec.describe Loga::Sidekiq6::JobLogger do
   subject(:job_logger) { described_class.new }
 
   let(:target) { StringIO.new }
@@ -20,6 +20,11 @@ RSpec.describe Loga::Sidekiq5::JobLogger do
       device: target,
       format: :gelf,
     )
+  end
+
+  # https://github.com/mperham/sidekiq/blob/v6.1.2/lib/sidekiq/job_logger.rb
+  it 'inherits from ::Sidekiq::JobLogger' do
+    expect(subject).to be_a(::Sidekiq::JobLogger)
   end
 
   describe '#call' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,17 +30,22 @@ when /unit/
   rspec_pattern = 'unit/**/*_spec.rb'
   require 'loga'
 when /sidekiq(?<version>\d+)/
-  sidekiq_specs = [
-    'spec/loga/sidekiq/**/*_spec.rb',
-    'spec/loga/sidekiq_spec.rb',
-  ]
-
-  version = $LAST_MATCH_INFO['version']
-
-  sidekiq_specs << 'spec/integration/sidekiq5_spec.rb' if version == '51'
-  sidekiq_specs << 'spec/integration/sidekiq6_spec.rb' if version == '6'
-
-  rspec_pattern = sidekiq_specs.join(',')
+  case $LAST_MATCH_INFO['version']
+  when '51'
+    rspec_pattern = [
+      'spec/integration/sidekiq5_spec.rb',
+      'spec/loga/sidekiq5/**/*_spec.rb',
+      'spec/loga/sidekiq_spec.rb',
+    ].join(',')
+  when '6'
+    rspec_pattern = [
+      'spec/integration/sidekiq6_spec.rb',
+      'spec/loga/sidekiq6/**/*_spec.rb',
+      'spec/loga/sidekiq_spec.rb',
+    ].join(',')
+  else
+    raise 'FIXME: Unknown sidekiq - update this file.'
+  end
 
   require 'sidekiq'
   require 'sidekiq/cli'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,12 +29,16 @@ when /sinatra/
 when /unit/
   rspec_pattern = 'unit/**/*_spec.rb'
   require 'loga'
-when /sidekiq/
+when /sidekiq(?<version>\d+)/
   sidekiq_specs = [
-    'integration/sidekiq_spec.rb',
     'spec/loga/sidekiq/**/*_spec.rb',
     'spec/loga/sidekiq_spec.rb',
   ]
+
+  version = $LAST_MATCH_INFO['version']
+
+  sidekiq_specs << 'spec/integration/sidekiq5_spec.rb' if version == '51'
+  sidekiq_specs << 'spec/integration/sidekiq6_spec.rb' if version == '6'
 
   rspec_pattern = sidekiq_specs.join(',')
 


### PR DESCRIPTION
# Problem
The job logger is not compatible with sidekiq 6

# Solution

In sidekiq6 the logging was rewritten. Sidekiq now has a
`::Sidekiq::Context.current` in which it holds data about the current job
in `Thread.current`. The job_logger is a bit more complex and there is a
custom logging class. 

There is an option to pass a formatter to sidekiq, instead of changing the logger 🤔 

Loga instrumentation

```
{
    "_class": "MySidekiqWorker",
    "_jid": "c16c0bdf9209e5c89d9edc12",
    "_duration": 0.0,
    "_created_at": 1603714080.6039722,
    "_enqueued_at": 1603714080.604033,
    "_queue": "default",
    "_retry": true,
    "_params": ["Bob"],
    "_type": "sidekiq",
    "_service.name": "hello_world_app",
    "_service.version": "1.0",
    "_tags": "",
    "short_message": "MySidekiqWorker with jid: 'c16c0bdf9209e5c89d9edc12' done",
    "timestamp": 1603714080.605,
    "host": "my-laptop",
    "level": 6,
    "version": "1.1"
}
```

Logging from the worker:

```
{
    "_class": "MySidekiqWorker",
    "_jid": "c16c0bdf9209e5c89d9edc12",
    "_service.name": "hello_world_app",
    "_service.version": "1.0",
    "_tags": "",
    "short_message": "Hello from MySidekiqWorker",
    "timestamp": 1603714080.604,
    "host":"my-laptop",
    "level":6,
    "version":"1.1"
}
```

TODO:
- [x] decide what to do with the Logger#log_at -> https://github.com/mperham/sidekiq/blob/v6.1.2/lib/sidekiq/logger.rb#L75
   ⚠️  Sidekiq extends the logger in https://github.com/mperham/sidekiq/blob/v6.1.2/lib/sidekiq.rb#L210
Mainly to add a Logger#log_at method https://github.com/mperham/sidekiq/blob/v6.1.2/lib/sidekiq/logger.rb#L75
- [x] decide where to put _sidekiq.class, _sidekiq.jid, _sidekiq.elapsed, maybe just use _class, _jid, _duration and not add them to `_sidekiq.*` / prefix all sidekiq params with `_sidekiq`
-  [x] version bump