### PR TITLE
Fix thread safety issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.5.4] - 2021-03-24
+### Fixed
+- Remove state from Rack middleware, to prevent race conditions where one request would overwrite the state of another
+
 ## [2.5.3] - 2020-10-27
 ### Fixed
 - Support for sidekiq 6 - previous versions were causing sidekiq to crash with `Internal exception!`

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "rails", "~> 6.0.0"
 
 group :test do
-  gem "simplecov"
+  gem "simplecov", "~> 0.17.0"
 end
 
 gemspec path: "../"

--- a/gemfiles/sidekiq51.gemfile
+++ b/gemfiles/sidekiq51.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "sidekiq", "~> 5.1.0"
 
 group :test do
-  gem "simplecov"
+  gem "simplecov", "~> 0.17.0"
 end
 
 gemspec path: "../"

--- a/gemfiles/sidekiq6.gemfile
+++ b/gemfiles/sidekiq6.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "sidekiq", "~> 6.0"
 
 group :test do
-  gem "simplecov"
+  gem "simplecov", "~> 0.17.0"
 end
 
 gemspec path: "../"

--- a/gemfiles/sinatra14.gemfile
+++ b/gemfiles/sinatra14.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "sinatra", "~> 1.4.0"
 
 group :test do
-  gem "simplecov"
+  gem "simplecov", "~> 0.17.0"
 end
 
 gemspec path: "../"

--- a/gemfiles/unit.gemfile
+++ b/gemfiles/unit.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 group :test do
-  gem "simplecov"
+  gem "simplecov", "~> 0.17.0"
 end
 
 gemspec path: "../"

--- a/lib/loga/rack/logger.rb
+++ b/lib/loga/rack/logger.rb
@@ -39,6 +39,7 @@ module Loga
       end
 
       def generate_data(request, status, started_at)
+        controller = request.controller_action_name
         {
           'method' => request.request_method,
           'path' => request.original_path,
@@ -48,7 +49,7 @@ module Loga
           'user_agent' => request.user_agent,
           'duration' => duration_in_ms(started_at, Time.now),
           'status' => status.to_i,
-        }.tap { |d| d['controller'] = request.controller_action_name if request.controller_action_name }
+        }.tap { |d| d['controller'] = controller if controller }
       end
 
       def logger

--- a/lib/loga/rack/logger.rb
+++ b/lib/loga/rack/logger.rb
@@ -7,65 +7,55 @@ module Loga
         @app = app
       end
 
-      def call(env)
+      def call(env, started_at = Time.now)
         request = Loga::Rack::Request.new(env)
         env['loga.request.original_path'] = request.path
 
         if logger.respond_to?(:tagged)
-          logger.tagged(compute_tags(request)) { call_app(request, env) }
+          logger.tagged(compute_tags(request)) { call_app(request, env, started_at) }
         else
-          call_app(request, env)
+          call_app(request, env, started_at)
         end
       end
 
       private
 
-      attr_reader :data, :env, :request, :started_at
-
-      def call_app(request, env)
-        @data       = {}
-        @env        = env
-        @request    = request
-        @started_at = Time.now
-
-        @app.call(env).tap { |status, _headers, _body| data['status'] = status.to_i }
+      def call_app(request, env, started_at)
+        status, _headers, _body = @app.call(env)
       ensure
-        set_data
-        send_message
-      end
+        data = generate_data(request, status, started_at)
 
-      # rubocop:disable Metrics/LineLength
-      def set_data
-        data['method']     = request.request_method
-        data['path']       = request.original_path
-        data['params']     = request.filtered_parameters
-        data['request_id'] = request.uuid
-        data['request_ip'] = request.ip
-        data['user_agent'] = request.user_agent
-        data['controller'] = request.controller_action_name if request.controller_action_name
-        data['duration']   = duration_in_ms(started_at, Time.now)
+        exception = compute_exception(env)
 
-        # If data['status'] is nil we assume an exception was raised when calling the application
-        data['status']     ||= 500
-      end
-      # rubocop:enable Metrics/LineLength
-
-      def send_message
         event = Loga::Event.new(
           data:       { request: data },
-          exception:  compute_exception,
-          message:    compute_message,
+          exception:  exception,
+          message:    compute_message(request, data),
           timestamp:  started_at,
           type:       'request',
         )
-        logger.public_send(compute_level, event)
+
+        exception ? logger.error(event) : logger.info(event)
+      end
+
+      def generate_data(request, status, started_at)
+        {
+          'method' => request.request_method,
+          'path' => request.original_path,
+          'params' => request.filtered_parameters,
+          'request_id' => request.uuid,
+          'request_ip' => request.ip,
+          'user_agent' => request.user_agent,
+          'duration' => duration_in_ms(started_at, Time.now),
+          'status' => status.to_i,
+        }.tap { |d| d['controller'] = request.controller_action_name if request.controller_action_name }
       end
 
       def logger
         Loga.logger
       end
 
-      def compute_message
+      def compute_message(request, data)
         '%<method>s %<filtered_full_path>s %<status>d in %<duration>dms' % {
           method:             request.request_method,
           filtered_full_path: request.filtered_full_path,
@@ -74,17 +64,12 @@ module Loga
         }
       end
 
-      def compute_level
-        compute_exception ? :error : :info
-      end
-
-      def compute_exception
-        filter_exceptions.include?(exception.class.to_s) ? nil : exception
-      end
-
-      def exception
-        env['loga.exception'] || env['action_dispatch.exception'] ||
+      def compute_exception(env)
+        exception =
+          env['loga.exception'] || env['action_dispatch.exception'] ||
           env['sinatra.error'] || env['rack.exception']
+
+        filter_exceptions.include?(exception.class.to_s) ? nil : exception
       end
 
       def filter_exceptions

--- a/lib/loga/rack/logger.rb
+++ b/lib/loga/rack/logger.rb
@@ -40,6 +40,7 @@ module Loga
 
       def generate_data(request, status, started_at)
         controller = request.controller_action_name
+        status ||= 500
         {
           'method' => request.request_method,
           'path' => request.original_path,

--- a/lib/loga/version.rb
+++ b/lib/loga/version.rb
@@ -1,3 +1,3 @@
 module Loga
-  VERSION = '2.5.3'.freeze
+  VERSION = '2.5.4'.freeze
 end

--- a/spec/integration/sinatra_spec.rb
+++ b/spec/integration/sinatra_spec.rb
@@ -68,7 +68,6 @@ RSpec.describe 'Structured logging with Sinatra', :with_hostname, :timecop do
     end
     let(:data) do
       {
-        'status' => 200,
         'method' => 'GET',
         'path'   => '/ok',
         'params' => { 'username'=>'yoshi' },
@@ -76,6 +75,7 @@ RSpec.describe 'Structured logging with Sinatra', :with_hostname, :timecop do
         'request_ip' => '127.0.0.1',
         'user_agent' => nil,
         'duration'   => 0,
+        'status' => 200,
       }
     end
     let(:data_as_text)  { "data=#{{ request: data }.inspect}" }

--- a/spec/unit/loga/rack/logger_spec.rb
+++ b/spec/unit/loga/rack/logger_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'rack/test'
 
+# rubocop:disable RSpec/VerifiedDoubles RSpec/MessageSpies
 describe Loga::Rack::Logger do
   subject(:middleware) { described_class.new(app) }
 
@@ -34,7 +35,11 @@ describe Loga::Rack::Logger do
     let(:level) { details[:level] }
 
     it 'instantiates a Loga::Event' do
-      expect(Loga::Event).to receive(:new).with(
+      allow(Loga::Event).to receive(:new).and_call_original
+
+      middleware.call(env, started_at)
+
+      expect(Loga::Event).to have_received(:new).with(
         data:      {
           request: {
             'status'     => response_status,
@@ -52,8 +57,6 @@ describe Loga::Rack::Logger do
         timestamp: started_at,
         type:      'request',
       )
-
-      middleware.call(env, started_at)
     end
 
     it "logs the Loga::Event with severity #{details[:level]}" do
@@ -125,8 +128,11 @@ describe Loga::Rack::Logger do
       it 'calls the tags and computes them' do
         middleware.call(env)
 
-        expect(fake_tag_proc).to have_received(:call).with(instance_of(Loga::Rack::Request))
+        expect(fake_tag_proc)
+          .to have_received(:call)
+          .with(instance_of(Loga::Rack::Request))
       end
     end
   end
 end
+# rubocop:enable RSpec/VerifiedDoubles RSpec/MessageSpies


### PR DESCRIPTION
Having a stateful middleware is a problem in a multithreaded environment - different requests could overwrite each other if they overlap in execution.

In our case, since we have four instance variables (`data`, `env`, `request`, `started_at`), these are all at risk of being mutated in another thread.

Couple of errors we've seen in Originations API recently that seem to be related:
https://app.honeybadger.io/projects/59679/faults/78535198
https://app.honeybadger.io/projects/59679/faults/78536458

This PR clears out state from the middleware, also slightly reworks the specs to avoid having to stub so much