### PR TITLE
Add open telemetry fields to messages by default if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.8.0] - 2023-11-14
+### Added
+- Support open-telemetry and add trace_id and span_id to logs events
+
 ## [2.7.0] - 2023-03-28
 ### Added
 - Support for sidekiq 7

--- a/lib/loga/formatters/gelf_formatter.rb
+++ b/lib/loga/formatters/gelf_formatter.rb
@@ -107,7 +107,6 @@ module Loga
         {
           trace_id: span.context.hex_trace_id,
           span_id: span.context.hex_span_id,
-          operation: span.respond_to?(:name) ? span.name : 'undefined',
         }
       end
 

--- a/lib/loga/formatters/gelf_formatter.rb
+++ b/lib/loga/formatters/gelf_formatter.rb
@@ -39,12 +39,7 @@ module Loga
       private
 
       def build_event(time, message)
-        event = case message
-                when Loga::Event
-                  message
-                else
-                  Loga::Event.new(message: message)
-                end
+        event = message.is_a?(Loga::Event) ? message : Loga::Event.new(message: message)
 
         event.timestamp ||= time
         # Overwrite sidekiq_context data anything manually specified
@@ -54,6 +49,7 @@ module Loga
           hash.merge! compute_type(event.type)
           # Overwrite hash with Loga's additional fields
           hash.merge! loga_additional_fields
+          hash.merge! open_telemetry_fields
         end
         event
       end
@@ -100,6 +96,18 @@ module Loga
             version: @service_version,
           },
           tags: current_tags.join(' '),
+        }
+      end
+
+      def open_telemetry_fields
+        return {} unless defined?(::OpenTelemetry::Trace)
+
+        span = ::OpenTelemetry::Trace.current_span
+
+        {
+          trace_id: span.context.hex_trace_id,
+          span_id: span.context.hex_span_id,
+          operation: span.respond_to?(:name) ? span.name : 'undefined',
         }
       end
 

--- a/lib/loga/version.rb
+++ b/lib/loga/version.rb
@@ -1,3 +1,3 @@
 module Loga
-  VERSION = '2.7.0'.freeze
+  VERSION = '2.8.0'.freeze
 end


### PR DESCRIPTION
Support open-telemetry and add trace_id and span_id to logs events.